### PR TITLE
Vx delete

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@napi-rs/canvas": "^0.1.41",
         "@the-convocation/twitter-scraper": "^0.4.0",
-        "axios": "^1.4.0",
+        "axios": "1.7.4",
         "discord.js": "^14.12.0-dev.1690071081-6307f81.0",
         "dotenv": "^16.3.1",
         "moment-timezone": "^0.5.43",
@@ -19,17 +19,17 @@
       }
     },
     "node_modules/@discordjs/builders": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.6.5.tgz",
-      "integrity": "sha512-SdweyCs/+mHj+PNhGLLle7RrRFX9ZAhzynHahMCLqp5Zeq7np7XC6/mgzHc79QoVlQ1zZtOkTTiJpOZu5V8Ufg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.7.0.tgz",
+      "integrity": "sha512-GDtbKMkg433cOZur8Dv6c25EHxduNIBsxeHrsRoIM8+AwmEZ8r0tEpckx/sHwTLwQPOF3e2JWloZh9ofCaMfAw==",
       "dependencies": {
-        "@discordjs/formatters": "^0.3.2",
-        "@discordjs/util": "^1.0.1",
-        "@sapphire/shapeshift": "^3.9.2",
-        "discord-api-types": "0.37.50",
+        "@discordjs/formatters": "^0.3.3",
+        "@discordjs/util": "^1.0.2",
+        "@sapphire/shapeshift": "^3.9.3",
+        "discord-api-types": "0.37.61",
         "fast-deep-equal": "^3.1.3",
         "ts-mixer": "^6.0.3",
-        "tslib": "^2.6.1"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.11.0"
@@ -44,60 +44,84 @@
       }
     },
     "node_modules/@discordjs/formatters": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.2.tgz",
-      "integrity": "sha512-lE++JZK8LSSDRM5nLjhuvWhGuKiXqu+JZ/DsOR89DVVia3z9fdCJVcHF2W/1Zxgq0re7kCzmAJlCMMX3tetKpA==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.3.tgz",
+      "integrity": "sha512-wTcI1Q5cps1eSGhl6+6AzzZkBBlVrBdc9IUhJbijRgVjCNIIIZPgqnUj3ntFODsHrdbGU8BEG9XmDQmgEEYn3w==",
       "dependencies": {
-        "discord-api-types": "0.37.50"
+        "discord-api-types": "0.37.61"
       },
       "engines": {
         "node": ">=16.11.0"
       }
     },
     "node_modules/@discordjs/rest": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.0.1.tgz",
-      "integrity": "sha512-/eWAdDRvwX/rIE2tuQUmKaxmWeHmGealttIzGzlYfI4+a7y9b6ZoMp8BG/jaohs8D8iEnCNYaZiOFLVFLQb8Zg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.2.0.tgz",
+      "integrity": "sha512-nXm9wT8oqrYFRMEqTXQx9DUTeEtXUDMmnUKIhZn6O2EeDY9VCdwj23XCPq7fkqMPKdF7ldAfeVKyxxFdbZl59A==",
       "dependencies": {
-        "@discordjs/collection": "^1.5.3",
-        "@discordjs/util": "^1.0.1",
+        "@discordjs/collection": "^2.0.0",
+        "@discordjs/util": "^1.0.2",
         "@sapphire/async-queue": "^1.5.0",
         "@sapphire/snowflake": "^3.5.1",
         "@vladfrangu/async_event_emitter": "^2.2.2",
-        "discord-api-types": "0.37.50",
-        "magic-bytes.js": "^1.0.15",
-        "tslib": "^2.6.1",
-        "undici": "5.22.1"
+        "discord-api-types": "0.37.61",
+        "magic-bytes.js": "^1.5.0",
+        "tslib": "^2.6.2",
+        "undici": "5.27.2"
       },
       "engines": {
         "node": ">=16.11.0"
       }
     },
+    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.0.0.tgz",
+      "integrity": "sha512-YTWIXLrf5FsrLMycpMM9Q6vnZoR/lN2AWX23/Cuo8uOOtS8eHB2dyQaaGnaF8aZPYnttf2bkLMcXn/j6JUOi3w==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@discordjs/util": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.0.1.tgz",
-      "integrity": "sha512-d0N2yCxB8r4bn00/hvFZwM7goDcUhtViC5un4hPj73Ba4yrChLSJD8fy7Ps5jpTLg1fE9n4K0xBLc1y9WGwSsA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.0.2.tgz",
+      "integrity": "sha512-IRNbimrmfb75GMNEjyznqM1tkI7HrZOf14njX7tCAAUetyZM1Pr8hX/EK2lxBCOgWDRmigbp24fD1hdMfQK5lw==",
       "engines": {
         "node": ">=16.11.0"
       }
     },
     "node_modules/@discordjs/ws": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.0.1.tgz",
-      "integrity": "sha512-avvAolBqN3yrSvdBPcJ/0j2g42ABzrv3PEL76e3YTp2WYMGH7cuspkjfSyNWaqYl1J+669dlLp+YFMxSVQyS5g==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.0.2.tgz",
+      "integrity": "sha512-+XI82Rm2hKnFwAySXEep4A7Kfoowt6weO6381jgW+wVdTpMS/56qCvoXyFRY0slcv7c/U8My2PwIB2/wEaAh7Q==",
       "dependencies": {
-        "@discordjs/collection": "^1.5.3",
-        "@discordjs/rest": "^2.0.1",
-        "@discordjs/util": "^1.0.1",
+        "@discordjs/collection": "^2.0.0",
+        "@discordjs/rest": "^2.1.0",
+        "@discordjs/util": "^1.0.2",
         "@sapphire/async-queue": "^1.5.0",
-        "@types/ws": "^8.5.5",
+        "@types/ws": "^8.5.9",
         "@vladfrangu/async_event_emitter": "^2.2.2",
-        "discord-api-types": "0.37.50",
-        "tslib": "^2.6.1",
-        "ws": "^8.13.0"
+        "discord-api-types": "0.37.61",
+        "tslib": "^2.6.2",
+        "ws": "^8.14.2"
       },
       "engines": {
         "node": ">=16.11.0"
+      }
+    },
+    "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.0.0.tgz",
+      "integrity": "sha512-YTWIXLrf5FsrLMycpMM9Q6vnZoR/lN2AWX23/Cuo8uOOtS8eHB2dyQaaGnaF8aZPYnttf2bkLMcXn/j6JUOi3w==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
+      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@napi-rs/canvas": {
@@ -259,25 +283,24 @@
       }
     },
     "node_modules/@sapphire/async-queue": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.0.tgz",
-      "integrity": "sha512-JkLdIsP8fPAdh9ZZjrbHWR/+mZj0wvKS5ICibcLrRI1j84UmLMshx5n9QmL8b95d4onJ2xxiyugTgSAX7AalmA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.2.tgz",
+      "integrity": "sha512-7X7FFAA4DngXUl95+hYbUF19bp1LGiffjJtu7ygrZrbdCSsdDDBaSjB7Akw0ZbOu6k0xpXyljnJ6/RZUvLfRdg==",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/@sapphire/shapeshift": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.9.2.tgz",
-      "integrity": "sha512-YRbCXWy969oGIdqR/wha62eX8GNHsvyYi0Rfd4rNW6tSVVa8p0ELiMEuOH/k8rgtvRoM+EMV7Csqz77YdwiDpA==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.9.6.tgz",
+      "integrity": "sha512-4+Na/fxu2SEepZRb9z0dbsVh59QtwPuBg/UVaDib3av7ZY14b14+z09z6QVn0P6Dv6eOU2NDTsjIi0mbtgP56g==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "lodash": "^4.17.21"
       },
       "engines": {
-        "node": ">=v14.0.0",
-        "npm": ">=7.0.0"
+        "node": ">=v18"
       }
     },
     "node_modules/@sapphire/snowflake": {
@@ -306,22 +329,25 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.8.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.0.tgz",
-      "integrity": "sha512-LzcWltT83s1bthcvjBmiBvGJiiUe84NWRHkw+ZV6Fr41z2FbIzvc815dk2nQ3RAKMuN2fkenM/z3Xv2QzEpYxQ=="
+      "version": "20.11.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.17.tgz",
+      "integrity": "sha512-QmgQZGWu1Yw9TDyAP9ZzpFJKynYNeOvwMJmaxABfieQoVoiVOS6MN1WSpqpRcbeA5+RW82kraAVxCCJg+780Qw==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/ws": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.6.tgz",
-      "integrity": "sha512-8B5EO9jLVCy+B58PLHvLDuOD8DRVMgQzq8d55SjLCOn9kqGyqOvy27exVaTio1q1nX5zLu8/6N0n2ThSxOM6tg==",
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.9.tgz",
+      "integrity": "sha512-jbdrY0a8lxfdTp/+r7Z4CkycbOFN8WX+IOchLJr3juT/xzbJ8URyTVSJ/hvNdadTgM1mnedb47n+Y31GsFnQlg==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@vladfrangu/async_event_emitter": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.2.2.tgz",
-      "integrity": "sha512-HIzRG7sy88UZjBJamssEczH5q7t5+axva19UbZLO6u0ySbYPrwzWiXBcC0WuHyhKKoeCyneH+FvYzKQq/zTtkQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.2.4.tgz",
+      "integrity": "sha512-ButUPz9E9cXMLgvAW8aLAKKJJsPu1dY1/l/E8xzLFuysowXygs6GBcyunK9rnGC4zTsnIc2mQo71rGw9U+Ykug==",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
@@ -333,24 +359,14 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.16.0"
       }
     },
     "node_modules/combined-stream": {
@@ -381,29 +397,29 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.37.50",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.50.tgz",
-      "integrity": "sha512-X4CDiMnDbA3s3RaUXWXmgAIbY1uxab3fqe3qwzg5XutR3wjqi7M3IkgQbsIBzpqBN2YWr/Qdv7JrFRqSgb4TFg=="
+      "version": "0.37.61",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.61.tgz",
+      "integrity": "sha512-o/dXNFfhBpYHpQFdT6FWzeO7pKc838QeeZ9d91CfVAtpr5XLK4B/zYxQbYgPdoMiTDvJfzcsLW5naXgmHGDNXw=="
     },
     "node_modules/discord.js": {
-      "version": "14.13.0",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.13.0.tgz",
-      "integrity": "sha512-Kufdvg7fpyTEwANGy9x7i4od4yu5c6gVddGi5CKm4Y5a6sF0VBODObI3o0Bh7TGCj0LfNT8Qp8z04wnLFzgnbA==",
+      "version": "14.14.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.14.1.tgz",
+      "integrity": "sha512-/hUVzkIerxKHyRKopJy5xejp4MYKDPTszAnpYxzVVv4qJYf+Tkt+jnT2N29PIPschicaEEpXwF2ARrTYHYwQ5w==",
       "dependencies": {
-        "@discordjs/builders": "^1.6.5",
-        "@discordjs/collection": "^1.5.3",
-        "@discordjs/formatters": "^0.3.2",
-        "@discordjs/rest": "^2.0.1",
-        "@discordjs/util": "^1.0.1",
-        "@discordjs/ws": "^1.0.1",
-        "@sapphire/snowflake": "^3.5.1",
-        "@types/ws": "^8.5.5",
-        "discord-api-types": "0.37.50",
-        "fast-deep-equal": "^3.1.3",
-        "lodash.snakecase": "^4.1.1",
-        "tslib": "^2.6.1",
-        "undici": "5.22.1",
-        "ws": "^8.13.0"
+        "@discordjs/builders": "^1.7.0",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.3.3",
+        "@discordjs/rest": "^2.1.0",
+        "@discordjs/util": "^1.0.2",
+        "@discordjs/ws": "^1.0.2",
+        "@sapphire/snowflake": "3.5.1",
+        "@types/ws": "8.5.9",
+        "discord-api-types": "0.37.61",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "tslib": "2.6.2",
+        "undici": "5.27.2",
+        "ws": "8.14.2"
       },
       "engines": {
         "node": ">=16.11.0"
@@ -426,15 +442,16 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -492,9 +509,9 @@
       "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
     },
     "node_modules/magic-bytes.js": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.3.0.tgz",
-      "integrity": "sha512-NobauZB5uA4l7IqgjeXx0gn0qBIikI5iFwy/4zUG9+OKLy69/uzn+su5UZPoDfJtVu3ywV4HYAOjPYVPPQqAAA=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.8.0.tgz",
+      "integrity": "sha512-lyWpfvNGVb5lu8YUAbER0+UMBTdR63w2mcSUlhhBTyVbxJvjgqwyAf3AZD6MprgK0uHuBoWXSDAMWLupX83o3Q=="
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
@@ -591,14 +608,6 @@
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
       "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ=="
     },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/tough-cookie": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
@@ -624,20 +633,25 @@
       "integrity": "sha512-k43M7uCG1AkTyxgnmI5MPwKoUvS/bRvLvUb7+Pgpdlmok8AoqmUaZxUUw8zKM5B1lqZrt41GjYgnvAi0fppqgQ=="
     },
     "node_modules/tslib": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/undici": {
-      "version": "5.22.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
-      "integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
+      "version": "5.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.27.2.tgz",
+      "integrity": "sha512-iS857PdOEy/y3wlM3yRp+6SNQQ6xU0mmZcwRSriqk+et/cwWAtwmIGf6WkoDN2EK/AMdCO/dfXzIwi+rFMrjjQ==",
       "dependencies": {
-        "busboy": "^1.6.0"
+        "@fastify/busboy": "^2.0.0"
       },
       "engines": {
         "node": ">=14.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/universalify": {
       "version": "0.2.0",
@@ -693,17 +707,17 @@
   },
   "dependencies": {
     "@discordjs/builders": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.6.5.tgz",
-      "integrity": "sha512-SdweyCs/+mHj+PNhGLLle7RrRFX9ZAhzynHahMCLqp5Zeq7np7XC6/mgzHc79QoVlQ1zZtOkTTiJpOZu5V8Ufg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.7.0.tgz",
+      "integrity": "sha512-GDtbKMkg433cOZur8Dv6c25EHxduNIBsxeHrsRoIM8+AwmEZ8r0tEpckx/sHwTLwQPOF3e2JWloZh9ofCaMfAw==",
       "requires": {
-        "@discordjs/formatters": "^0.3.2",
-        "@discordjs/util": "^1.0.1",
-        "@sapphire/shapeshift": "^3.9.2",
-        "discord-api-types": "0.37.50",
+        "@discordjs/formatters": "^0.3.3",
+        "@discordjs/util": "^1.0.2",
+        "@sapphire/shapeshift": "^3.9.3",
+        "discord-api-types": "0.37.61",
         "fast-deep-equal": "^3.1.3",
         "ts-mixer": "^6.0.3",
-        "tslib": "^2.6.1"
+        "tslib": "^2.6.2"
       }
     },
     "@discordjs/collection": {
@@ -712,49 +726,68 @@
       "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ=="
     },
     "@discordjs/formatters": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.2.tgz",
-      "integrity": "sha512-lE++JZK8LSSDRM5nLjhuvWhGuKiXqu+JZ/DsOR89DVVia3z9fdCJVcHF2W/1Zxgq0re7kCzmAJlCMMX3tetKpA==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.3.tgz",
+      "integrity": "sha512-wTcI1Q5cps1eSGhl6+6AzzZkBBlVrBdc9IUhJbijRgVjCNIIIZPgqnUj3ntFODsHrdbGU8BEG9XmDQmgEEYn3w==",
       "requires": {
-        "discord-api-types": "0.37.50"
+        "discord-api-types": "0.37.61"
       }
     },
     "@discordjs/rest": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.0.1.tgz",
-      "integrity": "sha512-/eWAdDRvwX/rIE2tuQUmKaxmWeHmGealttIzGzlYfI4+a7y9b6ZoMp8BG/jaohs8D8iEnCNYaZiOFLVFLQb8Zg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.2.0.tgz",
+      "integrity": "sha512-nXm9wT8oqrYFRMEqTXQx9DUTeEtXUDMmnUKIhZn6O2EeDY9VCdwj23XCPq7fkqMPKdF7ldAfeVKyxxFdbZl59A==",
       "requires": {
-        "@discordjs/collection": "^1.5.3",
-        "@discordjs/util": "^1.0.1",
+        "@discordjs/collection": "^2.0.0",
+        "@discordjs/util": "^1.0.2",
         "@sapphire/async-queue": "^1.5.0",
         "@sapphire/snowflake": "^3.5.1",
         "@vladfrangu/async_event_emitter": "^2.2.2",
-        "discord-api-types": "0.37.50",
-        "magic-bytes.js": "^1.0.15",
-        "tslib": "^2.6.1",
-        "undici": "5.22.1"
+        "discord-api-types": "0.37.61",
+        "magic-bytes.js": "^1.5.0",
+        "tslib": "^2.6.2",
+        "undici": "5.27.2"
+      },
+      "dependencies": {
+        "@discordjs/collection": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.0.0.tgz",
+          "integrity": "sha512-YTWIXLrf5FsrLMycpMM9Q6vnZoR/lN2AWX23/Cuo8uOOtS8eHB2dyQaaGnaF8aZPYnttf2bkLMcXn/j6JUOi3w=="
+        }
       }
     },
     "@discordjs/util": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.0.1.tgz",
-      "integrity": "sha512-d0N2yCxB8r4bn00/hvFZwM7goDcUhtViC5un4hPj73Ba4yrChLSJD8fy7Ps5jpTLg1fE9n4K0xBLc1y9WGwSsA=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.0.2.tgz",
+      "integrity": "sha512-IRNbimrmfb75GMNEjyznqM1tkI7HrZOf14njX7tCAAUetyZM1Pr8hX/EK2lxBCOgWDRmigbp24fD1hdMfQK5lw=="
     },
     "@discordjs/ws": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.0.1.tgz",
-      "integrity": "sha512-avvAolBqN3yrSvdBPcJ/0j2g42ABzrv3PEL76e3YTp2WYMGH7cuspkjfSyNWaqYl1J+669dlLp+YFMxSVQyS5g==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.0.2.tgz",
+      "integrity": "sha512-+XI82Rm2hKnFwAySXEep4A7Kfoowt6weO6381jgW+wVdTpMS/56qCvoXyFRY0slcv7c/U8My2PwIB2/wEaAh7Q==",
       "requires": {
-        "@discordjs/collection": "^1.5.3",
-        "@discordjs/rest": "^2.0.1",
-        "@discordjs/util": "^1.0.1",
+        "@discordjs/collection": "^2.0.0",
+        "@discordjs/rest": "^2.1.0",
+        "@discordjs/util": "^1.0.2",
         "@sapphire/async-queue": "^1.5.0",
-        "@types/ws": "^8.5.5",
+        "@types/ws": "^8.5.9",
         "@vladfrangu/async_event_emitter": "^2.2.2",
-        "discord-api-types": "0.37.50",
-        "tslib": "^2.6.1",
-        "ws": "^8.13.0"
+        "discord-api-types": "0.37.61",
+        "tslib": "^2.6.2",
+        "ws": "^8.14.2"
+      },
+      "dependencies": {
+        "@discordjs/collection": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.0.0.tgz",
+          "integrity": "sha512-YTWIXLrf5FsrLMycpMM9Q6vnZoR/lN2AWX23/Cuo8uOOtS8eHB2dyQaaGnaF8aZPYnttf2bkLMcXn/j6JUOi3w=="
+        }
       }
+    },
+    "@fastify/busboy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
+      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA=="
     },
     "@napi-rs/canvas": {
       "version": "0.1.41",
@@ -827,14 +860,14 @@
       "optional": true
     },
     "@sapphire/async-queue": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.0.tgz",
-      "integrity": "sha512-JkLdIsP8fPAdh9ZZjrbHWR/+mZj0wvKS5ICibcLrRI1j84UmLMshx5n9QmL8b95d4onJ2xxiyugTgSAX7AalmA=="
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.2.tgz",
+      "integrity": "sha512-7X7FFAA4DngXUl95+hYbUF19bp1LGiffjJtu7ygrZrbdCSsdDDBaSjB7Akw0ZbOu6k0xpXyljnJ6/RZUvLfRdg=="
     },
     "@sapphire/shapeshift": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.9.2.tgz",
-      "integrity": "sha512-YRbCXWy969oGIdqR/wha62eX8GNHsvyYi0Rfd4rNW6tSVVa8p0ELiMEuOH/k8rgtvRoM+EMV7Csqz77YdwiDpA==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.9.6.tgz",
+      "integrity": "sha512-4+Na/fxu2SEepZRb9z0dbsVh59QtwPuBg/UVaDib3av7ZY14b14+z09z6QVn0P6Dv6eOU2NDTsjIi0mbtgP56g==",
       "requires": {
         "fast-deep-equal": "^3.1.3",
         "lodash": "^4.17.21"
@@ -859,22 +892,25 @@
       }
     },
     "@types/node": {
-      "version": "20.8.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.0.tgz",
-      "integrity": "sha512-LzcWltT83s1bthcvjBmiBvGJiiUe84NWRHkw+ZV6Fr41z2FbIzvc815dk2nQ3RAKMuN2fkenM/z3Xv2QzEpYxQ=="
+      "version": "20.11.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.17.tgz",
+      "integrity": "sha512-QmgQZGWu1Yw9TDyAP9ZzpFJKynYNeOvwMJmaxABfieQoVoiVOS6MN1WSpqpRcbeA5+RW82kraAVxCCJg+780Qw==",
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/ws": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.6.tgz",
-      "integrity": "sha512-8B5EO9jLVCy+B58PLHvLDuOD8DRVMgQzq8d55SjLCOn9kqGyqOvy27exVaTio1q1nX5zLu8/6N0n2ThSxOM6tg==",
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.9.tgz",
+      "integrity": "sha512-jbdrY0a8lxfdTp/+r7Z4CkycbOFN8WX+IOchLJr3juT/xzbJ8URyTVSJ/hvNdadTgM1mnedb47n+Y31GsFnQlg==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@vladfrangu/async_event_emitter": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.2.2.tgz",
-      "integrity": "sha512-HIzRG7sy88UZjBJamssEczH5q7t5+axva19UbZLO6u0ySbYPrwzWiXBcC0WuHyhKKoeCyneH+FvYzKQq/zTtkQ=="
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.2.4.tgz",
+      "integrity": "sha512-ButUPz9E9cXMLgvAW8aLAKKJJsPu1dY1/l/E8xzLFuysowXygs6GBcyunK9rnGC4zTsnIc2mQo71rGw9U+Ykug=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -882,21 +918,13 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "axios": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "requires": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
-      }
-    },
-    "busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "requires": {
-        "streamsearch": "^1.1.0"
       }
     },
     "combined-stream": {
@@ -921,29 +949,29 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "discord-api-types": {
-      "version": "0.37.50",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.50.tgz",
-      "integrity": "sha512-X4CDiMnDbA3s3RaUXWXmgAIbY1uxab3fqe3qwzg5XutR3wjqi7M3IkgQbsIBzpqBN2YWr/Qdv7JrFRqSgb4TFg=="
+      "version": "0.37.61",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.61.tgz",
+      "integrity": "sha512-o/dXNFfhBpYHpQFdT6FWzeO7pKc838QeeZ9d91CfVAtpr5XLK4B/zYxQbYgPdoMiTDvJfzcsLW5naXgmHGDNXw=="
     },
     "discord.js": {
-      "version": "14.13.0",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.13.0.tgz",
-      "integrity": "sha512-Kufdvg7fpyTEwANGy9x7i4od4yu5c6gVddGi5CKm4Y5a6sF0VBODObI3o0Bh7TGCj0LfNT8Qp8z04wnLFzgnbA==",
+      "version": "14.14.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.14.1.tgz",
+      "integrity": "sha512-/hUVzkIerxKHyRKopJy5xejp4MYKDPTszAnpYxzVVv4qJYf+Tkt+jnT2N29PIPschicaEEpXwF2ARrTYHYwQ5w==",
       "requires": {
-        "@discordjs/builders": "^1.6.5",
-        "@discordjs/collection": "^1.5.3",
-        "@discordjs/formatters": "^0.3.2",
-        "@discordjs/rest": "^2.0.1",
-        "@discordjs/util": "^1.0.1",
-        "@discordjs/ws": "^1.0.1",
-        "@sapphire/snowflake": "^3.5.1",
-        "@types/ws": "^8.5.5",
-        "discord-api-types": "0.37.50",
-        "fast-deep-equal": "^3.1.3",
-        "lodash.snakecase": "^4.1.1",
-        "tslib": "^2.6.1",
-        "undici": "5.22.1",
-        "ws": "^8.13.0"
+        "@discordjs/builders": "^1.7.0",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.3.3",
+        "@discordjs/rest": "^2.1.0",
+        "@discordjs/util": "^1.0.2",
+        "@discordjs/ws": "^1.0.2",
+        "@sapphire/snowflake": "3.5.1",
+        "@types/ws": "8.5.9",
+        "discord-api-types": "0.37.61",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "tslib": "2.6.2",
+        "undici": "5.27.2",
+        "ws": "8.14.2"
       }
     },
     "dotenv": {
@@ -957,9 +985,9 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="
     },
     "form-data": {
       "version": "4.0.0",
@@ -1000,9 +1028,9 @@
       "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
     },
     "magic-bytes.js": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.3.0.tgz",
-      "integrity": "sha512-NobauZB5uA4l7IqgjeXx0gn0qBIikI5iFwy/4zUG9+OKLy69/uzn+su5UZPoDfJtVu3ywV4HYAOjPYVPPQqAAA=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.8.0.tgz",
+      "integrity": "sha512-lyWpfvNGVb5lu8YUAbER0+UMBTdR63w2mcSUlhhBTyVbxJvjgqwyAf3AZD6MprgK0uHuBoWXSDAMWLupX83o3Q=="
     },
     "mime-db": {
       "version": "1.52.0",
@@ -1073,11 +1101,6 @@
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
       "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ=="
     },
-    "streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
-    },
     "tough-cookie": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
@@ -1100,17 +1123,22 @@
       "integrity": "sha512-k43M7uCG1AkTyxgnmI5MPwKoUvS/bRvLvUb7+Pgpdlmok8AoqmUaZxUUw8zKM5B1lqZrt41GjYgnvAi0fppqgQ=="
     },
     "tslib": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "undici": {
-      "version": "5.22.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
-      "integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
+      "version": "5.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.27.2.tgz",
+      "integrity": "sha512-iS857PdOEy/y3wlM3yRp+6SNQQ6xU0mmZcwRSriqk+et/cwWAtwmIGf6WkoDN2EK/AMdCO/dfXzIwi+rFMrjjQ==",
       "requires": {
-        "busboy": "^1.6.0"
+        "@fastify/busboy": "^2.0.0"
       }
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "universalify": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@napi-rs/canvas": "^0.1.41",
-    "@the-convocation/twitter-scraper": "^0.4.0",
-    "axios": "^1.4.0",
+    "axios": "1.7.4",
     "discord.js": "^14.12.0-dev.1690071081-6307f81.0",
     "dotenv": "^16.3.1",
     "moment-timezone": "^0.5.43",

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ const {checkMessageAndVx, deleteVxLink} = require("./vx-util");
 const {handleReminder} = require("./reminder");
 const {handleGameStart, handleAnswerAttempt} = require("./typing-games");
 const {handleUserRoleRequest} = require("./role-assignment");
-const { registerCommands } = require('./register-commands');
+const {registerCommands} = require('./register-commands');
 
 
 const client = new DiscordClient({
@@ -25,14 +25,14 @@ client.on("ready", async (client) => {
     console.log(`${client.user.username} is ready!`);
 });
 
-client.on('interactionCreate', async (interaction) =>{
-    if(!interaction.isChatInputCommand()) return
+client.on('interactionCreate', async (interaction) => {
+    if (!interaction.isChatInputCommand()) return
     handleGameStart(interaction);
     handleUserRoleRequest(interaction);
     handleReminder(interaction);
 });
 
-client.on("messageCreate",  async (message) => {
+client.on("messageCreate", async (message) => {
     if (message.author.bot) {
         return;
     }
@@ -43,20 +43,5 @@ client.on("messageCreate",  async (message) => {
 });
 
 client.on("messageDelete", async (message) => {
-    console.log("Message deleted. Checking for vx links to delete.");
-    //I don't think the code below actually does anything tbh but if the bot starts crashing for vx-delete, try uncommenting this to see if it fixes anything
-    //
-    //if (message.partial) {
-    //    console.log("Partial message found.")
-    //    try {
-    //        await message.fetch();
-    //        console.log("Message fetched")
-    //    }
-    //    catch (error) {
-    //        console.error("Could not fetch partial message: ", error);
-    //        return;
-    //    }
-    //}
-
     await deleteVxLink(message);
 })

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ const client = new DiscordClient({
     ]
 });
 
-client.login(`${process.env.DISCORD_BOT_TOKEN}`).catch(error => console.log(error));
+client.login(process.env.DISCORD_BOT_TOKEN).catch(error => console.log(error));
 
 client.on("ready", async (client) => {
     await registerCommands(client);
@@ -41,3 +41,11 @@ client.on("messageCreate",  async (message) => {
     await handleAnswerAttempt(message);
 
 });
+
+client.on("messageDelete", async (message) => {
+    if (message.author.bot) {
+        return;
+    }
+
+    await checkMessageAndVx(message, deleted = true);
+})

--- a/src/index.js
+++ b/src/index.js
@@ -37,12 +37,9 @@ client.on("messageCreate",  async (message) => {
         return;
     }
 
-    console.log("Message content: ", message);
-
     handleReminder(message);
     await checkMessageAndVx(message);
     await handleAnswerAttempt(message);
-
 });
 
 client.on("messageDelete", async (message) => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 const {Client: DiscordClient, IntentsBitField, Partials} = require('discord.js');
 require('dotenv').config();
-const {checkMessageAndVx} = require("./vx-util");
+const {checkMessageAndVx, deleteVxLink} = require("./vx-util");
 const {handleReminder} = require("./reminder");
 const {handleGameStart, handleAnswerAttempt} = require("./typing-games");
 const {handleUserRoleRequest} = require("./role-assignment");
@@ -43,12 +43,7 @@ client.on("messageCreate",  async (message) => {
 });
 
 client.on("messageDelete", async (message) => {
-    console.log("Function is running");
-    if (message.author.bot) {
-        console.log("Bot is author; ending function")
-        return;
-    }
-
+    console.log("Message deleted. Checking for vx links to delete.");
     //I don't think the code below actually does anything tbh but if the bot starts crashing for vx-delete, try uncommenting this to see if it fixes anything
     //
     //if (message.partial) {
@@ -63,5 +58,5 @@ client.on("messageDelete", async (message) => {
     //    }
     //}
 
-    await checkMessageAndVx(message, deleted = true);
+    await deleteVxLink(message);
 })

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const {Client: DiscordClient, IntentsBitField} = require('discord.js');
+const {Client: DiscordClient, IntentsBitField, Partials} = require('discord.js');
 require('dotenv').config();
 const {checkMessageAndVx} = require("./vx-util");
 const {handleReminder} = require("./reminder");
@@ -14,7 +14,8 @@ const client = new DiscordClient({
         IntentsBitField.Flags.GuildMessages,
         IntentsBitField.Flags.MessageContent,
         IntentsBitField.Flags.GuildPresences,
-    ]
+    ],
+    partials: [Partials.Message, Partials.Channel] // Enables partial messages, channels, and reactions
 });
 
 client.login(process.env.DISCORD_BOT_TOKEN).catch(error => console.log(error));
@@ -36,6 +37,8 @@ client.on("messageCreate",  async (message) => {
         return;
     }
 
+    console.log("Message content: ", message);
+
     handleReminder(message);
     await checkMessageAndVx(message);
     await handleAnswerAttempt(message);
@@ -43,9 +46,25 @@ client.on("messageCreate",  async (message) => {
 });
 
 client.on("messageDelete", async (message) => {
+    console.log("Function is running");
     if (message.author.bot) {
+        console.log("Bot is author; ending function")
         return;
     }
+
+    //I don't think the code below actually does anything tbh but if the bot starts crashing for vx-delete, try uncommenting this to see if it fixes anything
+    //
+    //if (message.partial) {
+    //    console.log("Partial message found.")
+    //    try {
+    //        await message.fetch();
+    //        console.log("Message fetched")
+    //    }
+    //    catch (error) {
+    //        console.error("Could not fetch partial message: ", error);
+    //        return;
+    //    }
+    //}
 
     await checkMessageAndVx(message, deleted = true);
 })

--- a/src/vx-util.js
+++ b/src/vx-util.js
@@ -1,57 +1,131 @@
 const {twitterScraper} = require("./twitter");
 const axios = require('axios');
 
-const checkMessageAndVx = async (message) => {
-    if (message.content.includes("vxtwitter.com/") || message.content.includes("fxtwitter.com/") || message.content.includes("sxtwitter.com/") || message.content.includes("vxtiktok.com/")) {
-        console.log(`${message.author.username} used vx on their link manually in ${message.channel.name}!`)
-        return;
+const checkMessageAndVx = async (message, deleted = false) => {
+    if (deleted == false) {
+        if (message.content.includes("vxtwitter.com/") || message.content.includes("fxtwitter.com/") || message.content.includes("sxtwitter.com/") || message.content.includes("vxtiktok.com/")) {
+            console.log(`${message.author.username} used vx on their link manually in ${message.channel.name}!`)
+            return;
+        }
+
+        if (message.content.includes("ddinstagram.com/")) {
+            console.log(`${message.author.username} used dd on their Instagram link manually in ${message.channel.name}!`)
+            return;
+        }
+
+        let URL;
+
+        if (message.content.includes("twitter.com/") || message.content.includes("://x.com/") || message.content.includes("://www.x.com/")) {
+            URL = await vxTwitter(message);
+        }
+
+        if (message.content.includes("tiktok.com/")) {
+            URL = vxTikTok(message);
+        }
+
+        if (message.content.includes("instagram.com/")) {
+            URL = instaFix(message);
+        }
+
+        if (!URL) {
+            return;
+        }
+
+        if (isSpoiler(message.cleanContent)) {
+            URL = `||${URL}||`;
+        }
+
+        try {
+            await message.suppressEmbeds(true);
+        } catch (error) {
+            console.error(`Could not suppress embed for original message`, message.cleanContent, error);
+        }
+
+        const discordProfile = await createDiscordProfileFromMessage(message, URL);
+
+        try {
+            await postWithWebhook(message, URL, discordProfile);
+        } catch (error) {
+            console.error(`Unable to post new link with webhook`, message.cleanContent);
+        }
+
+        // second suppression to see if it improves missed embeds
+        setTimeout(async () => {
+            await message.suppressEmbeds();
+        }, 6000)
     }
+    else {
+        const twitterMatch = message.content.match(/(?:twitter\.com|x\.com)\/([^\s]+)/);
+        const instagramMatch = message.content.match(/(?:instagram\.com)\/([^\s]+)/);
+        const tiktokMatch = message.content.match(/(?:tiktok\.com)\/([^\s]+)/);
 
-    if (message.content.includes("ddinstagram.com/")) {
-        console.log(`${message.author.username} used dd on their Instagram link manually in ${message.channel.name}!`)
-        return;
+        if (twitterMatch) {
+            const commonPart = twitterMatch[1];
+
+            // Fetches messages from the channel
+            const fetchedMessages = await message.channel.messages.fetch({ limit: 100 });
+
+            const vxMessage = fetchedMessages.find(msg =>
+                (msg.content.includes('vxtwitter.com/') || msg.content.includes('sxtwitter.com') || msg.content.includes('fxtwitter.com')) &&
+                msg.content.includes(commonPart) &&
+                msg.author.bot
+            );
+
+            if (vxMessage) {
+                try {
+                    await vxMessage.delete();
+                    console.log(`Deleted vxtwitter link matching ${commonPart}`);
+                }
+                catch (error) {
+                    console.error(`Failed to delete vxtwitter message: ${error}`);
+                }
+            }
+        }
+        if (instagramMatch) {
+            const commonPart = instagramMatch[1];
+
+            // Fetches messages from the channel
+            const fetchedMessages = await message.channel.messages.fetch({ limit: 100 });
+
+            const vxMessage = fetchedMessages.find(msg =>
+                msg.content.includes('ddinstagram.com/') &&
+                msg.content.includes(commonPart) &&
+                msg.author.bot
+            );
+
+            if (vxMessage) {
+                try {
+                    await vxMessage.delete();
+                    console.log(`Deleted ddinstagram link matching ${commonPart}`);
+                }
+                catch (error) {
+                    console.error(`Failed to delete ddinstagram message: ${error}`);
+                }
+            }
+        }
+        if (tiktokMatch) {
+            const commonPart = tiktokMatch[1];
+
+            // Fetches messages from the channel
+            const fetchedMessages = await message.channel.messages.fetch({ limit: 100 });
+
+            const vxMessage = fetchedMessages.find(msg =>
+                msg.content.includes('vxtiktok.com/') &&
+                msg.content.includes(commonPart) &&
+                msg.author.bot
+            );
+
+            if (vxMessage) {
+                try {
+                    await vxMessage.delete();
+                    console.log(`Deleted vxtiktok link matching ${commonPart}`);
+                }
+                catch (error) {
+                    console.error(`Failed to delete vxtiktok message: ${error}`);
+                }
+            }
+        }
     }
-
-    let URL;
-
-    if (message.content.includes("twitter.com/") || message.content.includes("://x.com/") || message.content.includes("://www.x.com/")) {
-        URL = await vxTwitter(message);
-    }
-
-    if (message.content.includes("tiktok.com/")) {
-        URL = vxTikTok(message);
-    }
-
-    if (message.content.includes("instagram.com/")) {
-        URL = instaFix(message);
-    }
-
-    if (!URL) {
-        return;
-    }
-
-    if (isSpoiler(message.cleanContent)) {
-        URL = `||${URL}||`;
-    }
-
-    try {
-        await message.suppressEmbeds(true);
-    } catch (error) {
-        console.error(`Could not suppress embed for original message`, message.cleanContent, error);
-    }
-
-    const discordProfile = await createDiscordProfileFromMessage(message, URL);
-
-    try {
-        await postWithWebhook(message, URL, discordProfile);
-    } catch (error) {
-        console.error(`Unable to post new link with webhook`, message.cleanContent);
-    }
-
-    // second suppression to see if it improves missed embeds
-    setTimeout(async () => {
-        await message.suppressEmbeds();
-    }, 6000)
 }
 
 const removeParams = (message) => {

--- a/src/vx-util.js
+++ b/src/vx-util.js
@@ -3,145 +3,77 @@ const axios = require('axios');
 
 const urlMap = new Map();
 
-const checkMessageAndVx = async (message, deleted = false) => {
-    if (deleted == false) {
-        if (message.content.includes("vxtwitter.com/") || message.content.includes("fxtwitter.com/") || message.content.includes("sxtwitter.com/") || message.content.includes("vxtiktok.com/")) {
-            console.log(`${message.author.username} used vx on their link manually in ${message.channel.name}!`)
-            return;
-        }
-
-        if (message.content.includes("ddinstagram.com/")) {
-            console.log(`${message.author.username} used dd on their Instagram link manually in ${message.channel.name}!`)
-            return;
-        }
-
-        let URL;
-
-        if (message.content.includes("twitter.com/") || message.content.includes("://x.com/") || message.content.includes("://www.x.com/")) {
-            URL = await vxTwitter(message);
-
-            const twitterMatch = message.content.match(/(?:twitter\.com|x\.com)\/([^\s?]+)/);
-
-            if (twitterMatch) {
-                const commonPart = twitterMatch[1];
-                urlMap.set(message.id, commonPart);
-
-                checkMapSize();
-            }
-        }
-
-        if (message.content.includes("tiktok.com/")) {
-            URL = vxTikTok(message);
-
-            const tiktokMatch = message.content.match(/(?:tiktok\.com)\/([^\s]+)/);
-
-            if (tiktokMatch) {
-                const commonPart = tiktokMatch[1];
-                urlMap.set(message.id, commonPart);
-
-                checkMapSize();
-            }
-        }
-
-        if (message.content.includes("instagram.com/")) {
-            URL = instaFix(message);
-
-            const instagramMatch = message.content.match(/(?:instagram\.com)\/([^\s?]+)/);
-
-            if (instagramMatch) {
-                const commonPart = instagramMatch[1];
-                urlMap.set(message.id, commonPart);
-
-                checkMapSize();
-            }
-        }
-
-        if (!URL) {
-            return;
-        }
-
-        if (isSpoiler(message.cleanContent)) {
-            URL = `||${URL}||`;
-        }
-
-        try {
-            await message.suppressEmbeds(true);
-        } catch (error) {
-            console.error(`Could not suppress embed for original message`, message.cleanContent, error);
-        }
-
-        const discordProfile = await createDiscordProfileFromMessage(message, URL);
-
-        try {
-            await postWithWebhook(message, URL, discordProfile);
-        } catch (error) {
-            console.error(`Unable to post new link with webhook`, message.cleanContent);
-        }
-
-        // second suppression to see if it improves missed embeds
-        setTimeout(async () => {
-            try {
-                // Attempt to fetch the message in case it was deleted
-                const fetchedMessage = await message.channel.messages.fetch(message.id, { cache: true }).catch(() => null);
-
-                if (!fetchedMessage) {
-                    console.log("Message no longer exists, cannot suppress embed.");
-                    return;  // Exit if the message doesn't exist
-                }
-
-                await fetchedMessage.suppressEmbeds();
-                console.log("Successfully suppressed embed.");
-            } catch (error) {
-                console.error("Error while suppressing embed:", error);
-            }
-        }, 6000)
+const checkMessageAndVx = async (message) => {
+    if (message.content.includes("vxtwitter.com/") || message.content.includes("fxtwitter.com/") || message.content.includes("sxtwitter.com/") || message.content.includes("vxtiktok.com/")) {
+        console.log(`${message.author.username} used vx on their link manually in ${message.channel.name}!`)
+        return;
     }
-    else {
-        // Retrieve the unique portion of the URL using the ID of the deleted message, which is the only part of the message we are guaranteed access to upon deletion
-        const commonPart = urlMap.get(message.id);
 
-        if (!commonPart) {
-            console.log("No matching URL found for deleted message.");
-            return;
-        }
-
-        try {
-            // Fetches recent messages in channel since there is no way to directly access the time/date of the sent message and go to that point in channel history
-            console.log("Attempting to fetch messages in channel...")
-            const fetchedMessages = await message.channel.messages.fetch({ limit: 10 });
-            console.log("Messages successfully fetched.");
-
-            // Finds bot's vxtwitter message corresponding to the deleted message
-            const vxMessage = fetchedMessages.find(msg =>
-                {
-                // Extract the part after vx
-                const vxMatch = msg.content.match(/(?:vxtwitter\.com|vxtiktok\.com|ddinstagram\.com)\/([^\s]+)/);
-
-                // Check if the bot message matches the common part extracted from the original message
-                return vxMatch && vxMatch[1] === commonPart && msg.author.bot;
-                }
-            );
-
-            if (vxMessage) {
-                try {
-                    await vxMessage.delete();
-                    console.log(`Deleted vx link matching ${commonPart}`);
-                }
-                catch (error) {
-                    console.error(`Failed to delete vx message: ${error}`);
-                }
-            }
-        } catch (error) {
-            if (error.code === 10008) {
-                console.error("Message not found or no longer exists.")
-            } else {
-                console.error("An unexpected error occurred: ", error);
-            }
-        }
-
-        // Removes stored URL portion from map once it is handled
-        urlMap.delete(message.id);
+    if (message.content.includes("ddinstagram.com/")) {
+        console.log(`${message.author.username} used dd on their Instagram link manually in ${message.channel.name}!`)
+        return;
     }
+
+    let URL;
+
+    if (message.content.includes("twitter.com/") || message.content.includes("://x.com/") || message.content.includes("://www.x.com/")) {
+        URL = await vxTwitter(message);
+    }
+
+    if (message.content.includes("tiktok.com/")) {
+        URL = vxTikTok(message);
+    }
+
+    if (message.content.includes("instagram.com/")) {
+        URL = instaFix(message);
+    }
+
+    if (!URL) {
+        return;
+    }
+
+    if (isSpoiler(message.cleanContent)) {
+        URL = `||${URL}||`;
+    }
+
+    try {
+        const fetchedMessage = await message.channel.messages.fetch(message.id, { cache: true }).catch(() => null);
+
+        if (!fetchedMessage) {
+            console.log("Message no longer exists, cannot suppress embed.");
+            return;  // Exit if the message doesn't exist
+        }
+
+        await fetchedMessage.suppressEmbeds(true);
+    } catch (error) {
+        console.error(`Could not suppress embed for original message`, message.cleanContent, error);
+    }
+
+    const discordProfile = await createDiscordProfileFromMessage(message, URL);
+
+    try {
+        await postWithWebhook(message, URL, discordProfile);
+    } catch (error) {
+        console.error(`Unable to post new link with webhook`, message.cleanContent);
+    }
+
+    // second suppression to see if it improves missed embeds
+    setTimeout(async () => {
+        try {
+            // Attempt to fetch the message in case it was deleted
+            const fetchedMessage = await message.channel.messages.fetch(message.id, { cache: true }).catch(() => null);
+
+            if (!fetchedMessage) {
+                console.log("Message no longer exists, cannot suppress embed.");
+                return;  // Exit if the message doesn't exist
+            }
+
+            await fetchedMessage.suppressEmbeds();
+            console.log("Successfully suppressed embed.");
+        } catch (error) {
+            console.error("Error while suppressing embed:", error);
+        }
+    }, 6000)
 }
 
 const removeParams = (message) => {
@@ -300,7 +232,9 @@ const createDiscordProfileFromMessage = async (message, URL) => {
 const postWithWebhook = async (message, URL, discordProfile) => {
     const webhook = await message.channel.createWebhook(discordProfile).catch(err => console.error(err));
 
-    await webhook.send(URL).catch(err => console.error(err));
+    const webhookMessage = await webhook.send(URL).catch(err => console.error(err));
+    urlMap.set(message.id, webhookMessage.id);
+    checkMapSize();
     await webhook.delete().catch(err => console.error(err));
 }
 
@@ -314,6 +248,26 @@ const isSpoiler = (string) => {
     return false;
 }
 
+const deleteVxLink = async (message) => {
+    if (urlMap.has(message.id)) {
+        const botMessageId = urlMap.get(message.id);
+        try {
+            // Fetch bot's associated message in map
+            const fetchedBotMessage = await message.channel.messages.fetch(botMessageId);
+
+            await fetchedBotMessage.delete();
+            console.log(`Bot message with ID ${botMessageId} has been deleted.`);
+        }
+        catch (error) {
+            console.error(`Could not delete message with ID ${botMessageId}: `, error);
+        }
+    }
+    else {
+        console.log("Deleted message is not associated with a bot message stored in the map.");
+    }
+    return;
+}
+
 const checkMapSize = () => {
     if (urlMap.size > 10) {
         const oldestKey = urlMap.keys().next().value;
@@ -322,6 +276,7 @@ const checkMapSize = () => {
 }
 
 module.exports = {
-    checkMessageAndVx
+    checkMessageAndVx,
+    deleteVxLink
 }
 

--- a/src/vx-util.js
+++ b/src/vx-util.js
@@ -1,5 +1,7 @@
 const axios = require('axios');
 
+const VX_TWITTER_API = "https://api.vxtwitter.com/Twitter/status"
+
 const messageIdToBotMessageIdMap = new Map();
 
 const checkMessageAndVx = async (message) => {
@@ -116,7 +118,7 @@ const scanTweetForMedia = async (tweetID) => {
     let targetTweet;
 
     try {
-        targetTweet = await axios.get(`https://api.vxtwitter.com/Twitter/status/${tweetID}`);
+        targetTweet = await axios.get(`${VX_TWITTER_API}/${tweetID}`);
     } catch (error) {
         console.log('Could not get tweet information from VX Twitter API: \n', error);
     }

--- a/src/vx-util.js
+++ b/src/vx-util.js
@@ -41,13 +41,13 @@ const checkMessageAndVx = async (message) => {
         const fetchedMessage = await message.channel.messages.fetch(message.id, {cache: true}).catch(() => null);
 
         if (!fetchedMessage) {
-            console.log(`Message with link from ${message.author.username} no longer exists, cannot suppress embed.`);
+            console.log(`Message with link from ${message.author.username} in #${message.channel.name} no longer exists, cannot suppress embed.`);
             return;  // Exit if the message doesn't exist
         }
 
         await fetchedMessage.suppressEmbeds(true);
     } catch (error) {
-        console.error(`Could not suppress embed for original message`, message.cleanContent, error);
+        console.error(`Could not suppress embed for original message in #${message.channel.name}`, message.cleanContent, error);
     }
 
     const discordProfile = await createDiscordProfileFromMessage(message, URL);
@@ -65,12 +65,12 @@ const checkMessageAndVx = async (message) => {
             const fetchedMessage = await message.channel.messages.fetch(message.id, {cache: true}).catch(() => null);
 
             if (!fetchedMessage) {
-                console.log(`Message with link from ${message.author.username} no longer exists, cannot suppress embed.`);
+                console.log(`Message with link from ${message.author.username} in #${message.channel.name} no longer exists, cannot suppress embed.`);
                 return;  // Exit if the message doesn't exist
             }
 
             await fetchedMessage.suppressEmbeds();
-            console.log(`Successfully suppressed embed for message with link from ${message.author.username}.`);
+            console.log(`Successfully suppressed embed for message with link from ${message.author.username} in #${message.channel.name}.`);
         } catch (error) {
             console.error("Error while suppressing embed:", error);
         }
@@ -234,7 +234,7 @@ const isSpoiler = (string) => {
 
 const deleteVxLink = async (message) => {
     if (messageIdToBotMessageIdMap.has(message.id)) {
-        console.log(`Message with link from ${message.author.username} has been deleted, deleting bot message.`)
+        console.log(`Message with link from ${message.author.username} in #${message.channel.name} has been deleted, deleting bot message.`)
         const botMessageId = messageIdToBotMessageIdMap.get(message.id);
         try {
             // Fetch bot's associated message in map
@@ -242,9 +242,9 @@ const deleteVxLink = async (message) => {
 
             await fetchedBotMessage.delete();
             messageIdToBotMessageIdMap.delete(message.id);
-            console.log(`Bot message with ID ${botMessageId} has been deleted.`);
+            console.log(`Bot message with ID ${botMessageId} in #${message.channel.name} has been deleted.`);
         } catch (error) {
-            console.error(`Could not delete message with ID ${botMessageId}: `, error);
+            console.error(`Could not delete message with ID ${botMessageId} in #${message.channel.name}: `, error);
         }
     }
 }

--- a/src/vx-util.js
+++ b/src/vx-util.js
@@ -1,7 +1,6 @@
-const {twitterScraper} = require("./twitter");
 const axios = require('axios');
 
-const urlMap = new Map();
+const messageIdToBotMessageIdMap = new Map();
 
 const checkMessageAndVx = async (message) => {
     if (message.content.includes("vxtwitter.com/") || message.content.includes("fxtwitter.com/") || message.content.includes("sxtwitter.com/") || message.content.includes("vxtiktok.com/")) {
@@ -37,10 +36,10 @@ const checkMessageAndVx = async (message) => {
     }
 
     try {
-        const fetchedMessage = await message.channel.messages.fetch(message.id, { cache: true }).catch(() => null);
+        const fetchedMessage = await message.channel.messages.fetch(message.id, {cache: true}).catch(() => null);
 
         if (!fetchedMessage) {
-            console.log("Message no longer exists, cannot suppress embed.");
+            console.log(`Message with link from ${message.author.username} no longer exists, cannot suppress embed.`);
             return;  // Exit if the message doesn't exist
         }
 
@@ -61,15 +60,15 @@ const checkMessageAndVx = async (message) => {
     setTimeout(async () => {
         try {
             // Attempt to fetch the message in case it was deleted
-            const fetchedMessage = await message.channel.messages.fetch(message.id, { cache: true }).catch(() => null);
+            const fetchedMessage = await message.channel.messages.fetch(message.id, {cache: true}).catch(() => null);
 
             if (!fetchedMessage) {
-                console.log("Message no longer exists, cannot suppress embed.");
+                console.log(`Message with link from ${message.author.username} no longer exists, cannot suppress embed.`);
                 return;  // Exit if the message doesn't exist
             }
 
             await fetchedMessage.suppressEmbeds();
-            console.log("Successfully suppressed embed.");
+            console.log(`Successfully suppressed embed for message with link from ${message.author.username}.`);
         } catch (error) {
             console.error("Error while suppressing embed:", error);
         }
@@ -100,12 +99,12 @@ const vxTwitter = async (message) => {
     tweetURL = removeParams(tweetURL);
 
 
-    const tweetID = tweetURL.match(/\d+$/)[0];
+    const tweetID = tweetURL.match(/(?<=\/status\/)\d+/)[0];
 
-    let videoWasFound = await scanTweetForVideo(tweetID);
+    let mediaWasFound = await scanTweetForMedia(tweetID);
 
-    if (videoWasFound) {
-        console.log(`twitter link with video found in #${message.channel.name}, reposting with vx`);
+    if (mediaWasFound) {
+        console.log(`twitter link with media found in #${message.channel.name}, reposting with vx`);
         console.log(tweetURL);
         return tweetURL;
     }
@@ -113,13 +112,8 @@ const vxTwitter = async (message) => {
     return false;
 }
 
-const scanTweetForVideo = async (tweetID) => {
-
-    return true;
-    //TODO: Remove images and text maybe when embeds are ok again?
-
+const scanTweetForMedia = async (tweetID) => {
     let targetTweet;
-    let video;
 
     try {
         targetTweet = await axios.get(`https://api.vxtwitter.com/Twitter/status/${tweetID}`);
@@ -127,19 +121,7 @@ const scanTweetForVideo = async (tweetID) => {
         console.log('Could not get tweet information from VX Twitter API: \n', error);
     }
 
-    for (let media of targetTweet.data.media_extended) {
-        console.log(media)
-        if (media.type === 'video' || media.type === 'gif' || media.type === 'image') {
-            // TODO: have it VX images for now, maybe remove it later?
-            video = true;
-            break;
-        }
-        else {
-            console.log('video not found')
-        }
-    }
-
-    return video;
+    return targetTweet?.data?.hasMedia;
 }
 
 
@@ -233,7 +215,7 @@ const postWithWebhook = async (message, URL, discordProfile) => {
     const webhook = await message.channel.createWebhook(discordProfile).catch(err => console.error(err));
 
     const webhookMessage = await webhook.send(URL).catch(err => console.error(err));
-    urlMap.set(message.id, webhookMessage.id);
+    messageIdToBotMessageIdMap.set(message.id, webhookMessage.id);
     checkMapSize();
     await webhook.delete().catch(err => console.error(err));
 }
@@ -249,29 +231,26 @@ const isSpoiler = (string) => {
 }
 
 const deleteVxLink = async (message) => {
-    if (urlMap.has(message.id)) {
-        const botMessageId = urlMap.get(message.id);
+    if (messageIdToBotMessageIdMap.has(message.id)) {
+        console.log(`Message with link from ${message.author.username} has been deleted, deleting bot message.`)
+        const botMessageId = messageIdToBotMessageIdMap.get(message.id);
         try {
             // Fetch bot's associated message in map
             const fetchedBotMessage = await message.channel.messages.fetch(botMessageId);
 
             await fetchedBotMessage.delete();
+            messageIdToBotMessageIdMap.delete(message.id);
             console.log(`Bot message with ID ${botMessageId} has been deleted.`);
-        }
-        catch (error) {
+        } catch (error) {
             console.error(`Could not delete message with ID ${botMessageId}: `, error);
         }
     }
-    else {
-        console.log("Deleted message is not associated with a bot message stored in the map.");
-    }
-    return;
 }
 
 const checkMapSize = () => {
-    if (urlMap.size > 10) {
-        const oldestKey = urlMap.keys().next().value;
-        urlMap.delete(oldestKey);
+    if (messageIdToBotMessageIdMap.size > 10) {
+        const oldestKey = messageIdToBotMessageIdMap.keys().next().value;
+        messageIdToBotMessageIdMap.delete(oldestKey);
     }
 }
 

--- a/src/vx-util.js
+++ b/src/vx-util.js
@@ -1,6 +1,8 @@
 const {twitterScraper} = require("./twitter");
 const axios = require('axios');
 
+const urlMap = new Map();
+
 const checkMessageAndVx = async (message, deleted = false) => {
     if (deleted == false) {
         if (message.content.includes("vxtwitter.com/") || message.content.includes("fxtwitter.com/") || message.content.includes("sxtwitter.com/") || message.content.includes("vxtiktok.com/")) {
@@ -17,14 +19,35 @@ const checkMessageAndVx = async (message, deleted = false) => {
 
         if (message.content.includes("twitter.com/") || message.content.includes("://x.com/") || message.content.includes("://www.x.com/")) {
             URL = await vxTwitter(message);
+
+            const twitterMatch = message.content.match(/(?:twitter\.com|x\.com)\/([^\s?]+)/);
+
+            if (twitterMatch) {
+                const commonPart = twitterMatch[1];
+                urlMap.set(message.id, commonPart);
+            }
         }
 
         if (message.content.includes("tiktok.com/")) {
             URL = vxTikTok(message);
+
+            const tiktokMatch = message.content.match(/(?:tiktok\.com)\/([^\s]+)/);
+
+            if (tiktokMatch) {
+                const commonPart = tiktokMatch[1];
+                urlMap.set(message.id, commonPart);
+            }
         }
 
         if (message.content.includes("instagram.com/")) {
             URL = instaFix(message);
+
+            const instagramMatch = message.content.match(/(?:instagram\.com)\/([^\s]+)/);
+
+            if (instagramMatch) {
+                const commonPart = instagramMatch[1];
+                urlMap.set(message.id, commonPart);
+            }
         }
 
         if (!URL) {
@@ -55,76 +78,50 @@ const checkMessageAndVx = async (message, deleted = false) => {
         }, 6000)
     }
     else {
-        const twitterMatch = message.content.match(/(?:twitter\.com|x\.com)\/([^\s]+)/);
-        const instagramMatch = message.content.match(/(?:instagram\.com)\/([^\s]+)/);
-        const tiktokMatch = message.content.match(/(?:tiktok\.com)\/([^\s]+)/);
+        // Retrieve the unique portion of the URL using the ID of the deleted message, which is the only part of the message we are guaranteed access to upon deletion
+        const commonPart = urlMap.get(message.id);
 
-        if (twitterMatch) {
-            const commonPart = twitterMatch[1];
+        if (!commonPart) {
+            console.log("No matching URL found for deleted message.");
+            return;
+        }
 
-            // Fetches messages from the channel
-            const fetchedMessages = await message.channel.messages.fetch({ limit: 100 });
+        try {
+            // Fetches recent messages in channel since there is no way to directly access the time/date of the sent message and go to that point in channel history
+            console.log("Attempting to fetch messages in channel...")
+            const fetchedMessages = await message.channel.messages.fetch({ limit: 10 });
+            console.log("Messages successfully fetched.");
 
+            // Finds bot's vxtwitter message corresponding to the deleted message
             const vxMessage = fetchedMessages.find(msg =>
-                (msg.content.includes('vxtwitter.com/') || msg.content.includes('sxtwitter.com') || msg.content.includes('fxtwitter.com')) &&
-                msg.content.includes(commonPart) &&
-                msg.author.bot
+                {
+                // Extract the part after vx
+                const vxMatch = msg.content.match(/(?:vxtwitter\.com|vxtiktok\.com|ddinstagram\.com)\/([^\s]+)/);
+
+                // Check if the bot message matches the common part extracted from the original message
+                return vxMatch && vxMatch[1] === commonPart && msg.author.bot;
+                }
             );
 
             if (vxMessage) {
                 try {
                     await vxMessage.delete();
-                    console.log(`Deleted vxtwitter link matching ${commonPart}`);
+                    console.log(`Deleted vx link matching ${commonPart}`);
                 }
                 catch (error) {
-                    console.error(`Failed to delete vxtwitter message: ${error}`);
+                    console.error(`Failed to delete vx message: ${error}`);
                 }
             }
-        }
-        if (instagramMatch) {
-            const commonPart = instagramMatch[1];
-
-            // Fetches messages from the channel
-            const fetchedMessages = await message.channel.messages.fetch({ limit: 100 });
-
-            const vxMessage = fetchedMessages.find(msg =>
-                msg.content.includes('ddinstagram.com/') &&
-                msg.content.includes(commonPart) &&
-                msg.author.bot
-            );
-
-            if (vxMessage) {
-                try {
-                    await vxMessage.delete();
-                    console.log(`Deleted ddinstagram link matching ${commonPart}`);
-                }
-                catch (error) {
-                    console.error(`Failed to delete ddinstagram message: ${error}`);
-                }
+        } catch (error) {
+            if (error.code === 10008) {
+                console.error("Message not found or no longer exists.")
+            } else {
+                console.error("An unexpected error occurred: ", error);
             }
         }
-        if (tiktokMatch) {
-            const commonPart = tiktokMatch[1];
 
-            // Fetches messages from the channel
-            const fetchedMessages = await message.channel.messages.fetch({ limit: 100 });
-
-            const vxMessage = fetchedMessages.find(msg =>
-                msg.content.includes('vxtiktok.com/') &&
-                msg.content.includes(commonPart) &&
-                msg.author.bot
-            );
-
-            if (vxMessage) {
-                try {
-                    await vxMessage.delete();
-                    console.log(`Deleted vxtiktok link matching ${commonPart}`);
-                }
-                catch (error) {
-                    console.error(`Failed to delete vxtiktok message: ${error}`);
-                }
-            }
-        }
+        // Removes stored URL portion from map once it is handled
+        urlMap.delete(message.id);
     }
 }
 

--- a/src/vx-util.js
+++ b/src/vx-util.js
@@ -25,6 +25,8 @@ const checkMessageAndVx = async (message, deleted = false) => {
             if (twitterMatch) {
                 const commonPart = twitterMatch[1];
                 urlMap.set(message.id, commonPart);
+
+                checkMapSize();
             }
         }
 
@@ -36,17 +38,21 @@ const checkMessageAndVx = async (message, deleted = false) => {
             if (tiktokMatch) {
                 const commonPart = tiktokMatch[1];
                 urlMap.set(message.id, commonPart);
+
+                checkMapSize();
             }
         }
 
         if (message.content.includes("instagram.com/")) {
             URL = instaFix(message);
 
-            const instagramMatch = message.content.match(/(?:instagram\.com)\/([^\s]+)/);
+            const instagramMatch = message.content.match(/(?:instagram\.com)\/([^\s?]+)/);
 
             if (instagramMatch) {
                 const commonPart = instagramMatch[1];
                 urlMap.set(message.id, commonPart);
+
+                checkMapSize();
             }
         }
 
@@ -74,7 +80,20 @@ const checkMessageAndVx = async (message, deleted = false) => {
 
         // second suppression to see if it improves missed embeds
         setTimeout(async () => {
-            await message.suppressEmbeds();
+            try {
+                // Attempt to fetch the message in case it was deleted
+                const fetchedMessage = await message.channel.messages.fetch(message.id, { cache: true }).catch(() => null);
+
+                if (!fetchedMessage) {
+                    console.log("Message no longer exists, cannot suppress embed.");
+                    return;  // Exit if the message doesn't exist
+                }
+
+                await fetchedMessage.suppressEmbeds();
+                console.log("Successfully suppressed embed.");
+            } catch (error) {
+                console.error("Error while suppressing embed:", error);
+            }
         }, 6000)
     }
     else {
@@ -293,6 +312,13 @@ const isSpoiler = (string) => {
         }
     }
     return false;
+}
+
+const checkMapSize = () => {
+    if (urlMap.size > 10) {
+        const oldestKey = urlMap.keys().next().value;
+        urlMap.delete(oldestKey);
+    }
 }
 
 module.exports = {


### PR DESCRIPTION
Bot vx links will now delete automatically if the user deletes their original link. A crash that happens when the user deletes their link within 6 seconds of it being posted has also been fixed (related to how the embed suppression function worked).

Something to keep in mind for how the vx deletion works:
- The bot only checks the last 10 messages in chat, so users cannot delete older links. There is also no way for us to "jump" to the point in time they posted the message and check the channel from there, at least from what I've checked. Feel free to try messing around with that if you would like to improve the functionality.

